### PR TITLE
Bug 98614: Add localconfig option to override the submission SSL cert

### DIFF
--- a/conf/postfix/master.cf.in
+++ b/conf/postfix/master.cf.in
@@ -16,8 +16,10 @@ smtpd     pass  -       -       n       -       -       smtpd
 %%uncomment LOCAL:postjournal_enabled%%	-o smtpd_proxy_options=speed_adjust
 465    inet  n       -       n       -       -       smtpd
 %%uncomment SERVICE:opendkim%%	-o content_filter=scan:[%%zimbraLocalBindAddress%%]:10030
-	-o smtpd_tls_wrappermode=yes 
 	-o smtpd_sasl_auth_enable=yes
+	-o smtpd_tls_wrappermode=yes
+%%uncomment LOCAL:postfix_submission_smtpd_tls_key_file%%	-o smtpd_tls_key_file=@@postfix_submission_smtpd_tls_key_file@@
+%%uncomment LOCAL:postfix_submission_smtpd_tls_cert_file%%	-o smtpd_tls_cert_file=@@postfix_submission_smtpd_tls_cert_file@@
 	-o smtpd_client_restrictions=
 	-o smtpd_data_restrictions=
 	-o smtpd_helo_restrictions=
@@ -32,6 +34,8 @@ submission inet n      -       n       -       -       smtpd
 	-o smtpd_etrn_restrictions=reject
 	-o smtpd_sasl_auth_enable=%%zimbraMtaSaslAuthEnable%%
 	-o smtpd_tls_security_level=%%zimbraMtaTlsSecurityLevel%%
+%%uncomment LOCAL:postfix_submission_smtpd_tls_key_file%%	-o smtpd_tls_key_file=@@postfix_submission_smtpd_tls_key_file@@
+%%uncomment LOCAL:postfix_submission_smtpd_tls_cert_file%%	-o smtpd_tls_cert_file=@@postfix_submission_smtpd_tls_cert_file@@
 	-o smtpd_client_restrictions=permit_sasl_authenticated,reject
 	-o smtpd_data_restrictions=
 	-o smtpd_helo_restrictions=


### PR DESCRIPTION
Right now Zimbra doesn't support virtual hosts for authenticated SMTP.
And in the case of SNI never will as long as nginx isn't used as a SMTP
proxy as well (cf. [BZ-75623](https://bugzilla.zimbra.com/show_bug.cgi?id=75623)).

Even the simplest form isn't possible where the hosts use the ZCS CA
managed certificates internally but show another name like `mail.example.com`
to the outside world.  Or, where you've got two MTAs/MXes with correct
certs for their internal hostnames but provide a DNS alias like the above
for authenticated SMTP which fails over to the other MTA.

A workaround in 8.0 was to override the localconfig variables
`postfix_smtpd_tls_cert_file` and `postfix_smtpd_tls_key_file`
and make them point to a custom SSL certificate.  With the ldapification
in 8.6 this feature went away.

This change introduces the two localconfig variables

* `postfix_submission_smtpd_tls_key_file`
* `postfix_submission_smtpd_tls_cert_file`

which allow to override the certs of the submissions ports (587 and 465)
with another local, probably domain, certificate file.  We use this patch
widely in production.  It is intended as a workaround until virtual hosts
are supported for port 587 and 465.